### PR TITLE
develop を main へ反映（#35 のSEO対応を本番へ）

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,9 +1,0 @@
-/*--------------------------------------------
- microCMS用のクライアントを生成する
---------------------------------------------*/
-import { createClient } from 'microcms-js-sdk';
-
-export const client = createClient({
-  serviceDomain: process.env.MICROCMS_SERVICE_DOMAIN || '',
-  apiKey: process.env.MICROCMS_API_KEY || '',
-});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "dompurify": "^3.2.6",
         "jsdom": "^26.1.0",
         "lucide-react": "^0.516.0",
-        "microcms-js-sdk": "^3.2.0",
         "next": "15.5.7",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -2470,15 +2469,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/async-retry": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
-      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
-      "license": "MIT",
-      "dependencies": {
-        "retry": "0.13.1"
       }
     },
     "node_modules/autoprefixer": {
@@ -5363,18 +5353,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/microcms-js-sdk": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/microcms-js-sdk/-/microcms-js-sdk-3.2.0.tgz",
-      "integrity": "sha512-08TyGuBg3oBU27CUT0rn7GDgLu58pZ9F3aBpAa5boJJsllkz9BosLWsqOM9dfGTcVOga+/9tMtwHtmq17MK2KQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async-retry": "^1.3.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -6249,15 +6227,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/reusify": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "dompurify": "^3.2.6",
     "jsdom": "^26.1.0",
     "lucide-react": "^0.516.0",
-    "microcms-js-sdk": "^3.2.0",
     "next": "15.5.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/app/about-us/page.tsx
+++ b/src/app/about-us/page.tsx
@@ -1,9 +1,23 @@
+import type { Metadata } from "next";
 import React from "react";
 import { HiyokuThoughts } from "../../components/about-us/HiyokuThoughts";
 import { HiyokuPromise } from "../../components/about-us/HiyokuPromise";
 import {CompanyOverview} from "../../components/about-us/CompanyOverview";
 import { RecruitArea } from "@/components/shared/RecruitArea";
 import Pankuzu from "@/components/shared/Pankuzu";
+
+/*--------------------------------------------------------------------------
+  このページのメタデータ
+
+  BtoBでは発注前に「実在する会社か」を必ず調べられる。会社名・所在地・
+  事業内容が検索結果のスニペットに出るようにしておく。
+--------------------------------------------------------------------------*/
+export const metadata: Metadata = {
+  title: "私たちについて",
+  description:
+    "hiyoku合同会社（福岡市中央区）の会社概要と理念。「教育で世界の貧困差をなくす」を掲げ、企業のIT人材育成・エンジニア育成研修を行っています。",
+  alternates: { canonical: "/about-us" },
+};
 
 export default function AboutUsPage() {
 return (

--- a/src/app/api/blogs/[id]/route.ts
+++ b/src/app/api/blogs/[id]/route.ts
@@ -1,8 +1,14 @@
 /*-------------------------------------------------------
  特定のNEWS記事（ブログ記事）1件の詳細データを取得するAPIエンドポイント
+
+ データ元は microCMS から src/data/news.ts へ移した（2026-08）。
+ 経緯は src/data/news.ts の冒頭コメントを参照。
+
+ ⚠️ 記事が見つからない場合、microCMS 時代は例外が飛んで 500 を返していたが、
+    存在しないIDは「無い」だけでサーバーエラーではないので 404 を返すよう改めた。
 -------------------------------------------------------*/
 import { NextRequest, NextResponse } from 'next/server';
-import { client } from '../../../../../lib/client';
+import { getNewsById } from '@/data/news';
 
 export async function GET(
   request: NextRequest,
@@ -10,11 +16,16 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const data = await client.get({
-      endpoint: 'blogs',
-      contentId: id,
-    });
-    return NextResponse.json(data);
+    const article = getNewsById(id);
+
+    if (!article) {
+      return NextResponse.json(
+        { error: '記事が見つかりませんでした' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(article);
   } catch (error) {
     console.error('ブログ詳細の取得に失敗しました:', error);
     return NextResponse.json(
@@ -22,4 +33,4 @@ export async function GET(
       { status: 500 }
     );
   }
-} 
+}

--- a/src/app/api/blogs/route.ts
+++ b/src/app/api/blogs/route.ts
@@ -1,28 +1,32 @@
 /*-----------------------------------------------
  複数のNEWS記事（ブログ記事）のリストを取得するAPIエンドポイント
+
+ データ元は microCMS から src/data/news.ts へ移した（2026-08）。
+ 経緯は src/data/news.ts の冒頭コメントを参照。
+
+ ⚠️ レスポンスの形（contents / totalCount / offset / limit）は
+    microCMS 時代と同じにしてある。呼び出し側の
+    src/components/news/BlogTitleList.tsx を変更せずに済ませるため。
 -----------------------------------------------*/
 import { NextRequest, NextResponse } from 'next/server';
-import { client } from '../../../../lib/client';
+import { getNewsList } from '@/data/news';
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const offset = parseInt(searchParams.get('offset') || '0');
     const limit = parseInt(searchParams.get('limit') || '10');
-    const fields = searchParams.get('fields') || 'id,title,publishedAt';
-    const orders = searchParams.get('orders') || '-publishedAt';
 
-    const data = await client.get({
-      endpoint: 'blogs',
-      queries: {
-        offset,
-        limit,
-        fields,
-        orders,
-      },
-    });
+    // fields / orders は microCMS 側のクエリパラメータだった。
+    // 現在は getNewsList が「公開日の新しい順・id/title/publishedAt のみ」を
+    // 返す固定仕様なので受け取っても使わない。
+    // 呼び出し側が今も付けてくるため、互換のため無視して受け流す。
 
-    return NextResponse.json(data);
+    // 不正な数値が来たときに配列を壊さないよう最低限のガードを入れる
+    const safeOffset = Number.isFinite(offset) && offset > 0 ? offset : 0;
+    const safeLimit = Number.isFinite(limit) && limit > 0 ? limit : 10;
+
+    return NextResponse.json(getNewsList(safeOffset, safeLimit));
   } catch (error) {
     console.error('ブログデータの取得に失敗しました:', error);
     return NextResponse.json(
@@ -30,4 +34,4 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     );
   }
-} 
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,9 +14,50 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+/*--------------------------------------------------------------------------
+  サイト共通のメタデータ
+
+  【なぜ変更したか】
+  従来は title / description がここに1組あるだけで、全ページが
+  「hiyoku合同会社」「hiyokuCompany」という同じ値を返していた。
+  検索エンジンは title / description を「そのページが何のページか」を
+  判断する最大の手がかりに使うため、全ページ同一だと個別のクエリで
+  上位表示されない。実際、2026-08時点で検索流入はほぼゼロだった。
+
+  title に template を持たせておくと、各ページで
+    export const metadata = { title: "エンジニア研修の助成金活用" }
+  と書くだけで「エンジニア研修の助成金活用 | hiyoku合同会社」に展開される。
+--------------------------------------------------------------------------*/
 export const metadata: Metadata = {
-  title: "hiyoku合同会社",
-  description: "hiyokuCompany",
+  // 相対パスを絶対URLへ解決する基準。canonical と OGP画像の生成に必須。
+  // apex(hiyoku.co.jp)は www へ307リダイレクトされるので、正規ホストは www 側。
+  metadataBase: new URL("https://www.hiyoku.co.jp"),
+
+  title: {
+    // 各ページの title をこの形に展開する
+    template: "%s | hiyoku合同会社",
+    // トップページ用のフォールバック。
+    // src/app/page.tsx は 'use client' のため metadata を export できず、
+    // トップだけはこの default が使われる。
+    default: "hiyoku合同会社 | 企業向けエンジニア育成研修（福岡）",
+  },
+
+  description:
+    "hiyoku合同会社は、企業のIT人材育成を支援するエンジニア育成研修を提供しています。各種助成金に対応し、訓練の実施から出席簿・実施報告など必要書類のご用意までサポートします。",
+
+  // 検索結果には出ないが、SNSやチャットにURLを貼ったときの見え方を決める。
+  // 各ページで title を上書きすると openGraph.title も自動で追随する。
+  openGraph: {
+    type: "website",
+    locale: "ja_JP",
+    siteName: "hiyoku合同会社",
+    url: "https://www.hiyoku.co.jp",
+  },
+
+  // 同一内容が www / apex の両方で拾われる事故を防ぐ。
+  alternates: {
+    canonical: "/",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/news/[id]/page.tsx
+++ b/src/app/news/[id]/page.tsx
@@ -1,41 +1,88 @@
 /*----------------------------------
 　　NEWS画面のサニタイズをする
 　(サーバーサイド)
+
+  データ元は microCMS から src/data/news.ts へ移した（2026-08）。
+  経緯は src/data/news.ts の冒頭コメントを参照。
 ----------------------------------*/
 'use server'
+import type { Metadata } from 'next';
 import NewsDetailClient from './NewsDetailClient';
-import { client } from '../../../../lib/client';
+import { getNewsById, newsArticles } from '@/data/news';
 import createDOMPurify from 'dompurify';
 import { JSDOM } from 'jsdom';
 import { notFound } from 'next/navigation';
 
-interface BlogArticleProps {
-  id: string;
-  title: string;
-  content: string;
-  publishedAt: string;
-  [key: string]: unknown;
-  error?: unknown;
+/*
+  ビルド時に全記事のURLを静的生成する。
+  記事はリポジトリ内の固定データになったので、リクエストのたびに
+  組み立てる必要が無い。表示が速くなり、クロールもされやすくなる。
+*/
+export async function generateStaticParams() {
+  return newsArticles.map((article) => ({ id: article.id }));
+}
+
+/*
+  記事ごとの title / description を出す。
+
+  これが無いと、親の src/app/news/layout.tsx の metadata が使われて
+  全記事が「お知らせ | hiyoku合同会社」という同じ見出しになってしまい、
+  検索結果でどれがどの記事か区別できない。
+*/
+export async function generateMetadata(props: { params: Promise<{ id: string }> }): Promise<Metadata> {
+  const { id } = await props.params;
+  const article = getNewsById(id);
+
+  // 存在しないIDのときは親(layout)の metadata に任せる
+  if (!article) return {};
+
+  // description は本文から作る。
+  // 本文はHTMLなのでタグを除去し、連続する空白を潰してから頭を切り出す。
+  // 100字程度が検索結果に表示される目安。
+  const plainText = article.content
+    .replace(/<[^>]*>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const description = plainText.length > 100 ? `${plainText.slice(0, 100)}…` : plainText;
+
+  return {
+    title: article.title,
+    description,
+    alternates: { canonical: `/news/${article.id}` },
+    openGraph: {
+      type: 'article',
+      title: article.title,
+      description,
+      publishedTime: article.publishedAt,
+      modifiedTime: article.revisedAt,
+    },
+  };
 }
 
 export default async function NewsDetailPage(props: { params: Promise<{ id: string }> }) {
   const { id } = await props.params;
-  let article: BlogArticleProps | null = null;
-  try {
-    article = await client.get({
-      endpoint: 'blogs',
-      contentId: id,
-    });
-  } catch (error) {
-    console.error('ブログ詳細の取得に失敗しました:', error);
+  const article = getNewsById(id);
+
+  // 存在しないIDが来たら404。以前は microCMS のfetch失敗で拾っていた分岐。
+  if (!article) {
     notFound();
   }
 
-  if (!article || article.error) {
-    notFound();
-  }
+  /*
+    サーバーサイドでサニタイズ。
+    本文は自社リポジトリ内の固定データなので外部由来ではないが、
+    HTMLをそのまま dangerouslySetInnerHTML に渡す経路である以上、
+    記事を書き足す人が誤って危険なタグを入れた場合の保険として残している。
 
-  // サーバーサイドでサニタイズ
+    ⚠️ NewsDetailClient 側の useEffect でも同じ内容をもう一度サニタイズしており、
+       そちらはオプション無しで実行される。つまりここでオプションを足しても
+       ハイドレーション後に上書きされる。設定を変えたい場合は両方を直すこと。
+
+    【既知の挙動・今回は直していない】
+    デフォルト設定では a タグの target / rel が落ちるため、
+    記事中の外部リンクは同じタブで開く。これは microCMS 時代から同じで、
+    今回の変更で挙動は変わっていない。直すなら別の変更として扱う。
+  */
   const window = new JSDOM('').window;
   const DOMPurify = createDOMPurify(window as unknown as Window & typeof globalThis);
   const sanitizedContent = DOMPurify.sanitize(article.content);

--- a/src/app/news/layout.tsx
+++ b/src/app/news/layout.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+
+/*--------------------------------------------------------------------------
+  /news 用のメタデータ
+
+  【なぜ page.tsx ではなく layout.tsx に書くのか】
+  src/app/news/page.tsx は 'use client' で始まるクライアントコンポーネントで、
+  Next.js の仕様上クライアントコンポーネントからは metadata を export できない。
+  同じルート配下に layout.tsx を置けばサーバー側で metadata を定義できるので、
+  page.tsx をサーバーコンポーネントへ書き換えずに済むこの方法を採った。
+
+  （page.tsx 側をサーバーコンポーネント化して一覧部分だけ子コンポーネントへ
+    切り出す手もあるが、動いているコードに手を入れる範囲が広くなるため見送り）
+--------------------------------------------------------------------------*/
+export const metadata: Metadata = {
+  /*
+    title を単なる文字列にすると、ルートの layout.tsx で定義した
+    template（"%s | hiyoku合同会社"）が【この配下のページに継承されない】。
+    実際、個別記事のタイトルが社名なしの「e-HUB 交流会の開催案内」だけになった。
+    ここで template を張り直しておくと、/news/[id] 側は記事名だけを返せばよい。
+      default  … /news 自身のタイトル。ここにはさらに【ルートのtemplateが乗る】ので
+                 社名を書かない（書くと "お知らせ | hiyoku合同会社 | hiyoku合同会社" になる）
+      template … /news/[id] など配下のページに適用される形
+  */
+  title: {
+    default: "お知らせ",
+    template: "%s | hiyoku合同会社",
+  },
+  description:
+    "hiyoku合同会社からのお知らせ・新着情報の一覧です。エンジニア育成研修やサービスに関する最新情報を掲載しています。",
+  alternates: { canonical: "/news" },
+};
+
+export default function NewsLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  // レイアウトとしては何も足さず、children をそのまま通す。
+  // 目的は上の metadata を有効にすることだけ。
+  return <>{children}</>;
+}

--- a/src/app/recruit/page.tsx
+++ b/src/app/recruit/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import AboutHiyoku from "@/components/recruit/AboutHiyoku";
 import AboutWork from "@/components/recruit/AboutWork";
 import InterviewItems from "@/components/recruit/InterviewItems";
@@ -5,6 +6,15 @@ import Solicitation from "@/components/recruit/Solicitation";
 import FAQ from "@/components/recruit/FAQ";
 import Pankuzu from "@/components/shared/Pankuzu";
 
+
+// このページのメタデータ。求職者は「会社名 + 採用」で検索してくるので、
+// title は素直に「採用情報」でよい（template で社名が後ろに付く）。
+export const metadata: Metadata = {
+  title: "採用情報",
+  description:
+    "hiyoku合同会社の採用情報。エンジニア育成事業を一緒に伸ばしていく仲間を募集しています。仕事内容・社員インタビュー・よくある質問を掲載しています。",
+  alternates: { canonical: "/recruit" },
+};
 
 export default function RecruitPage() {
     return (

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from "next";
+
+/*--------------------------------------------------------------------------
+  robots.txt の生成
+
+  このファイルを置くだけで /robots.txt が自動生成される（Next.js App Router）。
+  2026-08時点では robots.txt が存在せず404だった。
+
+  【方針】
+  公開サイトなので全ページをクロール許可する。
+  除外しているのは /api 配下のみ（microCMS のプレビュー等、
+  検索結果に出す意味が無いエンドポイントのため）。
+
+  sitemap の場所をここで明示しておくと、Search Console へ登録しなくても
+  クローラーが sitemap.xml を見つけられる。
+--------------------------------------------------------------------------*/
+
+const BASE_URL = "https://www.hiyoku.co.jp";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: "/api/",
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/service/page.tsx
+++ b/src/app/service/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import React from "react";
 import { Header } from "@/components/header/Header";
 import { TopArea } from "@/components/service/TopArea";
@@ -7,6 +8,23 @@ import { CaseStudyArea } from "@/components/service/CaseStudyArea";
 import { FormArea } from "@/components/service/FormArea";
 import { SystemFeaturesArea } from "@/components/service/SystemFeaturesArea";
 // import { PamphletSectionArea } from "@/components/service/PamphletSectionArea";
+
+/*--------------------------------------------------------------------------
+  このページのメタデータ
+
+  サイト内で最も集客を担わせたいページなので、狙う検索クエリ
+  （「IT研修 助成金」「エンジニア研修 助成金」等）の語を title に入れている。
+
+  ⚠️ 助成金の「申請書類の作成・提出代行」は社会保険労務士の独占業務にあたる。
+     ここに書けるのは【訓練実施機関として自社が用意する書類】までなので、
+     文面を変える際も「申請代行」と読める表現は入れないこと。
+--------------------------------------------------------------------------*/
+export const metadata: Metadata = {
+  title: "エンジニア研修の助成金活用",
+  description:
+    "企業のIT・エンジニア研修に各種助成金を活用する方法をご案内します。コンピュータサイエンスからバックエンドまで、現場で通用するエンジニアを育成。訓練の実施と、出席簿・実施報告など必要書類のご用意までサポートします。",
+  alternates: { canonical: "/service" },
+};
 
 export default function ServicePage() {
     return (

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,72 @@
+import type { MetadataRoute } from "next";
+
+/*--------------------------------------------------------------------------
+  sitemap.xml の生成
+
+  このファイルを置くだけで /sitemap.xml が自動生成される（Next.js App Router）。
+  2026-08時点では sitemap.xml も robots.txt も存在せず、両方404だった。
+
+  【なぜ必要か】
+  サイトマップが無くてもクロールはされるが、
+  ・どのURLが存在するかをGoogleへ明示できる
+  ・Search Console に登録してインデックス状況を追える
+  という利点がある。特に被リンクが少ないサイトでは発見される速度が変わる。
+
+  【NEWSの個別記事について】
+  記事は src/data/news.ts に持っているので、そこから読んで自動で全件載せている。
+  記事を追加すれば、次のデプロイでサイトマップにも自動で入る。
+--------------------------------------------------------------------------*/
+import { newsArticles } from "@/data/news";
+
+// 正規ホスト。apex(hiyoku.co.jp)は www へ307リダイレクトされるため www 側を使う。
+const BASE_URL = "https://www.hiyoku.co.jp";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // ビルド時刻を最終更新日として使う。
+  // 記事のように更新日が個別に取れるものが増えたら、ここを差し替える。
+  const lastModified = new Date();
+
+  return [
+    {
+      url: BASE_URL,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+    {
+      // 集客の主戦場なので優先度を他より高くしている
+      url: `${BASE_URL}/service`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/about-us`,
+      lastModified,
+      changeFrequency: "yearly",
+      priority: 0.7,
+    },
+    {
+      // 記事が増えるページなので更新頻度を高めに申告する
+      url: `${BASE_URL}/news`,
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.6,
+    },
+    {
+      url: `${BASE_URL}/recruit`,
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+
+    // お知らせの個別記事。記事ごとの更新日を lastModified に使えるので、
+    // ビルド時刻より正確な情報をクローラーへ渡せる。
+    ...newsArticles.map((article) => ({
+      url: `${BASE_URL}/news/${article.id}`,
+      lastModified: new Date(article.revisedAt || article.publishedAt),
+      changeFrequency: "yearly" as const,
+      priority: 0.5,
+    })),
+  ];
+}

--- a/src/data/news.ts
+++ b/src/data/news.ts
@@ -1,0 +1,100 @@
+/*==========================================================================
+  お知らせ（NEWS）記事のデータ
+
+  【なぜコード内に持っているのか】
+  以前は microCMS（ヘッドレスCMS）から取得していたが、2026-08にやめた。理由は3つ。
+
+  1. microCMS のアカウントが会社の管理下に無く、招待も受けられない状態だった。
+     外部サービスに記事という資産を預けたまま、こちらから触れないのは危険。
+  2. 記事は13ヶ月で4本・画像ゼロ・全文で約1,500文字。
+     この規模にヘッドレスCMSは明らかに過剰で、運用の手間の方が大きい。
+  3. これにより環境変数（MICROCMS_*）がゼロになり、
+     ホスティングを移す際に引き継ぐ設定が無くなった。
+
+  【記事を追加・修正するには】
+  下の newsArticles 配列に要素を足す（先頭が新しい記事）。
+    - id          : URLになる（/news/<id>）。半角英数とハイフンで一意に付ける
+    - title       : 一覧と詳細に出る見出し
+    - content     : HTML文字列。<p> <br> <a> 程度で十分
+    - publishedAt : 公開日時（ISO 8601 / UTC）。一覧の並び順にも使われる
+  追加してコミットすれば、デプロイ時に反映される。
+
+  ※ id は microCMS 時代の値をそのまま引き継いでいる。
+     既に外部に共有されたURLや検索エンジンのインデックスを壊さないため。
+==========================================================================*/
+
+export type NewsArticle = {
+  id: string;
+  title: string;
+  /** HTML文字列。表示側でサニタイズしてから描画する */
+  content: string;
+  publishedAt: string;
+  createdAt: string;
+  updatedAt: string;
+  revisedAt: string;
+  category: string | null;
+};
+
+/** 公開日の新しい順に並べておく（一覧の表示順がこれに従う） */
+export const newsArticles: NewsArticle[] = [
+  {
+    id: "soa87wn8qw",
+    title: "2026年度新人研修がスタートしました！",
+    content: "<p>今年度の新入社員を対象とした新人研修がスタートしました！<br><br>研修の詳細は<a href=\"https://punctual-bear-1u1umvv.gamma.site/\" target=\"_blank\" rel=\"noopener noreferrer\">こちら</a></p>",
+    publishedAt: "2026-03-19T05:58:44.988Z",
+    createdAt: "2026-03-19T05:58:15.160Z",
+    updatedAt: "2026-04-05T15:00:05.252Z",
+    revisedAt: "2026-04-05T15:00:05.252Z",
+    category: null,
+  },
+  {
+    id: "5pomvkn7a",
+    title: "2026年度新人研修募集開始！",
+    content: "<p>新人研修3ヶ月集中プログラム2026年度の募集を開始しました！</p><p>【開催期間】<br>2026年4月6日〜6月30日<br>平日　9：00〜18：00 （但し17時45分から18時までの15分は日報記入）</p><p>【定員】<br>・対面研修25名</p><p>・オンライン研修　<br>　人数はご相談ください</p><p><br>詳しい情報は<a href=\"https://hiyoku-training-tadsofc.gamma.site/\" target=\"_blank\" rel=\"noopener noreferrer\">こちら</a>ご覧ください!</p><p>申込期限が2月16日、早期申込の割引期限が1月31日までの募集となりますので、少しでも興味がありましたらお気軽にお問い合わせください。</p>",
+    publishedAt: "2025-11-13T10:50:18.431Z",
+    createdAt: "2025-11-07T05:41:49.798Z",
+    updatedAt: "2025-12-10T10:52:37.016Z",
+    revisedAt: "2025-12-10T10:52:37.016Z",
+    category: null,
+  },
+  {
+    id: "cjv3-_19sri",
+    title: "e-HUB 交流会の開催案内",
+    content: "<p>ITエンジニアの方、これからITエンジニアを目指したい方、ITエンジニアと仕事をしたい方を対象に、合同会社Hiyokuが運営に参画している交流イベント「e-HUB」のご案内です！<br></p><p>イベントの詳細・参加方法は以下のURLよりご確認ください！<br><a href=\"https://e-hub.connpass.com/event/369962/\" target=\"_blank\" rel=\"noopener noreferrer nofollow\">https://e-hub.connpass.com/event/369962/</a></p><p></p><p>イベントではLT(Lightning Talk)を開催しており、LT登壇者も募集しております。<br>「e-HUB」に初めて参加する方、LTに初めて挑戦する方、大歓迎です！<br><br>【開催日時】</p><p>　2025/10/08 (水) 19:30〜22:00 (L.O. 21:30)</p><p>【開催場所】</p><p>　Dining Bar Milk Tea　福岡市中央区今泉1-9-19 Bulala 3F</p><p>　天神南駅から徒歩6分　<a href=\"https://maps.app.goo.gl/DQo4ZqkNYFYDzcn88\">https://maps.app.goo.gl/DQo4ZqkNYFYDzcn88</a></p><p>【会費】</p><p>　4,500円（フード付き2時間飲み放題コース ）</p><p>【LT ( Lightning Talk ) について】</p><p>　LT登壇者を募集しています！（先着4名）</p><p>　開催当日は20:00 ~ 20:30に2名、21:00 ~ 21:30に2名のタイムスケジュールでLTを開催します。</p><p>　LT登壇者には会場にて1,000円のキャッシュバックします！</p>",
+    publishedAt: "2025-09-28T13:26:21.956Z",
+    createdAt: "2025-09-28T13:26:21.956Z",
+    updatedAt: "2025-10-11T03:40:16.003Z",
+    revisedAt: "2025-10-11T03:40:16.003Z",
+    category: null,
+  },
+  {
+    id: "d1hqzx708jyr",
+    title: "Hiyokuのホームページをリニューアルしました！",
+    content: "<p>この度、ホームページを全面的にリニューアルしました！</p><p>デザインを一新し、より見やすくなりました🎶<br>スマートフォンでも快適にご利用いただけます📱</p><p>今後ともHiyoku合同会社をよろしくお願いいたします！</p>",
+    publishedAt: "2025-07-17T06:57:06.751Z",
+    createdAt: "2025-07-17T06:57:06.751Z",
+    updatedAt: "2025-07-17T08:03:29.407Z",
+    revisedAt: "2025-07-17T08:03:29.407Z",
+    category: null,
+  },
+];
+
+/**
+ * 一覧取得。microCMS の API と同じ戻り値の形を保っているので、
+ * 呼び出し側（/api/blogs）のレスポンス構造を変えずに済む。
+ */
+export function getNewsList(offset = 0, limit = 10) {
+  return {
+    contents: newsArticles
+      .slice(offset, offset + limit)
+      .map(({ id, title, publishedAt }) => ({ id, title, publishedAt })),
+    totalCount: newsArticles.length,
+    offset,
+    limit,
+  };
+}
+
+/** 1件取得。見つからなければ undefined */
+export function getNewsById(id: string): NewsArticle | undefined {
+  return newsArticles.find((article) => article.id === id);
+}


### PR DESCRIPTION
`develop` にマージ済みの #35 を本番へ反映するためのPRです。

## 含まれる変更

- #35 SEO: 全ページに固有のtitle/descriptionを追加し、microCMSへの依存を外す

`main` にあって `develop` に無いコミットは0件なので、コンフリクトはありません。

## 反映後に変わること

| ページ | Before | After |
|---|---|---|
| `/` | hiyoku合同会社 | hiyoku合同会社 \| 企業向けエンジニア育成研修（福岡） |
| `/service` | hiyoku合同会社 | エンジニア研修の助成金活用 \| hiyoku合同会社 |
| `/about-us` | hiyoku合同会社 | 私たちについて \| hiyoku合同会社 |
| `/news` | hiyoku合同会社 | お知らせ \| hiyoku合同会社 |
| `/recruit` | hiyoku合同会社 | 採用情報 \| hiyoku合同会社 |
| `/news/[id]` | hiyoku合同会社 | 各記事のタイトル \| hiyoku合同会社 |

- `sitemap.xml` / `robots.txt` が生成されます（現在は両方404）
- 記事4本が個別ページとして静的生成され、インデックス対象が5→9ページに増えます

## 確認手順（マージ後）

Vercelのデプロイ完了後、エッジの伝播ラグがあるため数分空けて複数回確認してください。

```bash
curl -s https://www.hiyoku.co.jp/service | grep -o "<title>[^<]*</title>"
curl -sI https://www.hiyoku.co.jp/sitemap.xml | head -1
curl -s https://www.hiyoku.co.jp/robots.txt
```

期待値:

```
<title>エンジニア研修の助成金活用 | hiyoku合同会社</title>
HTTP/2 200
User-Agent: *
Allow: /
Disallow: /api/
Sitemap: https://www.hiyoku.co.jp/sitemap.xml
```

## 問題が起きた場合

`git revert` して `main` に push すれば元に戻ります（Vercelの管理画面にアクセスできなくてもロールバック可能です）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
