### PR TITLE
ビルド生成物(.open-next / .wrangler)と .trash/ を .gitignore に追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,20 @@
 # production
 /build
 
+# Cloudflare/OpenNext のビルド生成物・ローカル状態。
+# 本番は Vercel。Cloudflare は切り替え手段(フェイルオーバー)として用意しており、
+# 構成一式は open-next.config.ts / wrangler.jsonc / docs/cloudflare-failover.md
+# にある(2026-08-14時点では feature/cloudflare-failover ブランチ)。
+# どちらもソースから作り直せる派生物なので、履歴には入れない。
+#
+# ⚠️ `.wrangler/` にだけ先頭の / を付けていないのは、入れ子で作られたものも拾うため。
+#    `/.wrangler/` と書くとルート直下しか無視されず、packages/*/.wrangler/ が素通りする。
+/.open-next/
+.wrangler/
+
+# 削除ファイルの退避先(プロジェクト内ゴミ箱)。履歴には入れない。
+.trash/
+
 # misc
 .DS_Store
 *.pem


### PR DESCRIPTION
## なぜ

`develop` で作業中に `.open-next/` と `.wrangler/` が合計 **2181件ステージされたまま**になっていた。
`.gitignore` に `/.next/` はあるが、この2つが抜けていたのが原因。

いずれもソースから作り直せるビルド生成物・ローカル状態なので、履歴に入れる価値がない。
`.wrangler/` は `wrangler dev` が作る miniflare の sqlite で、そもそも共有する意味がない。

## `feature/cloudflare-failover` との関係

あちらのブランチも同じ2行を `.gitignore` に足しています。Cloudflare 構成
（`open-next.config.ts` / `wrangler.jsonc` / `docs/cloudflare-failover.md`）が乗っているのもあちらです。

それでも develop 側に入れたいのは、**あのブランチがマージされるまで develop が無防備**だからです
（実際に2181件の事故が起きたのが develop 上）。

**表記をあちらと完全に一致させてあります**（`/.open-next/` と `.wrangler/`）。
両方マージされて重複しても、**どちらのブロックを消しても挙動は変わりません**。

### 重複した場合の影響（実測済み）

捨てブランチで「このPR → failover」の順に両方マージして確認しました。

| 項目 | 結果 |
|---|---|
| マージコンフリクト | **起きない**（足す位置が違うので自動マージされる） |
| 無視の挙動 | **同一**（gitignore は後勝ちだが、どちらも「無視」なので結果は変わらない） |
| 残る問題 | 同じ意図のブロックが2箇所に分かれ、読み手が「どっちが正？」と迷うだけ |

## 変更

`.gitignore` に3つ追加しただけで、**コードは1行も触っていません**。

| 追加 | 備考 |
|---|---|
| `/.open-next/` | OpenNext のビルド出力（101M）。failover ブランチと同一表記 |
| `.wrangler/` | wrangler/miniflare のローカル状態。**先頭に `/` を付けない**のは入れ子も拾うため（`/.wrangler/` だと `packages/*/.wrangler/` が素通りするのを実測で確認） |
| `.trash/` | 削除ファイルの退避先。重複なし |

## 確認したこと

- ステージ済み **2181 → 0**、`git status` がクリーンになること
- `npm ci` → `npm run build` が完走すること（15/15ページ生成、`sitemap.xml` / `robots.txt` を含む）
- ルート直下・入れ子の両方で `.wrangler/` が無視されること
- 退避した実体はローカルの `.trash/cloudflare-experiment-2026-08-13/` にあり、消していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)