### PR TITLE
.gitignore の Cloudflare 関連の重複を1箇所にまとめる

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,7 @@
 
 # Cloudflare/OpenNext のビルド生成物・ローカル状態。
 # 本番は Vercel。Cloudflare は切り替え手段(フェイルオーバー)として用意しており、
-# 構成一式は open-next.config.ts / wrangler.jsonc / docs/cloudflare-failover.md
-# にある(2026-08-14時点では feature/cloudflare-failover ブランチ)。
+# 構成一式は open-next.config.ts / wrangler.jsonc / docs/cloudflare-failover.md にある。
 # どちらもソースから作り直せる派生物なので、履歴には入れない。
 #
 # ⚠️ `.wrangler/` にだけ先頭の / を付けていないのは、入れ子で作られたものも拾うため。
@@ -53,7 +52,3 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-
-# Cloudflare (@opennextjs/cloudflare のビルド成果物)
-/.open-next/
-.wrangler/


### PR DESCRIPTION
## なぜ

#38 と #36 が独立に同じ2行（`/.open-next/` と `.wrangler/`）を `.gitignore` に足したため、
マージ後の develop で**同じエントリが2箇所に並んでいます**。

```
23〜32行目  ← #38（理由まで書いてある方）
57〜59行目  ← #36（コメント1行）
```

挙動は変わりませんが、次に読む人が「どっちが正？」と迷うので1箇所に寄せます。

## どちらを残したか

表記（`/.open-next/` と `.wrangler/`）は最初から一致させてあったので、**どちらを消しても挙動は同じ**です。
**理由まで書いてある側（前半）を残しました。**

- なぜこれらが生成されるのか（Vercel本番 + Cloudflareフェイルオーバー）
- 構成一式がどこにあるか
- **`.wrangler/` にだけ先頭 `/` を付けない理由**（付けると `packages/*/.wrangler/` が素通りする）

## ついでに直したこと

前半のコメントにあった「（2026-08-14時点では `feature/cloudflare-failover` ブランチ）」という但し書きを外しました。
#36 がマージされ、`open-next.config.ts` / `wrangler.jsonc` / `docs/cloudflare-failover.md` は
**develop 直下に存在する**ようになったためです（実在を確認済み）。

## 確認したこと

無視の挙動が変わっていないことを実測しました。

| パス | 効いた行 |
|---|---|
| `.open-next/x/a.js` | `:30 /.open-next/` |
| `.wrangler/x/b.sqlite` | `:31 .wrangler/` |
| `packages/sub/.wrangler/c.sqlite` | `:31 .wrangler/` ← 入れ子も拾えている |
| `.trash/x/d.txt` | `:34 .trash/` |

コードは1行も触っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)